### PR TITLE
Normalize e-mail storage and comparison

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
@@ -33,5 +34,21 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    /**
+     * Get the needed authorization credentials from the request.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array
+     */
+    protected function credentials(Request $request)
+    {
+        $username = $this->username();
+        $credentials = $request->only($username, 'password');
+        $credentials[$username] = strtolower($credentials[$username]);
+
+        return $credentials;
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -65,9 +65,10 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         $user = DB::transaction(function () use ($data) {
+            $lowerUserEmail = strtolower($data['student_number']);
             $user = User::make([
                 'name' => $data['name'],
-                'email' => $data['student_number'].'@alunos.uminho.pt',
+                'email' => $lowerUserEmail.'@alunos.uminho.pt',
                 'password' => bcrypt($data['password']),
             ]);
             $user->verification_token = str_random(32);

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -65,10 +65,10 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         $user = DB::transaction(function () use ($data) {
-            $lowerUserEmail = strtolower($data['student_number']);
+            $data['student_number'] = strtolower($data['student_number']);
             $user = User::make([
                 'name' => $data['name'],
-                'email' => $lowerUserEmail.'@alunos.uminho.pt',
+                'email' => $data['student_number'].'@alunos.uminho.pt',
                 'password' => bcrypt($data['password']),
             ]);
             $user->verification_token = str_random(32);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Validator::extend('student_number', function ($attribute, $value, $parameters, $validator) {
-            return preg_match('/^(a|pg)[0-9]+$/', $value) === 1;
+            return preg_match('/^(a|pg)[0-9]+$/i', $value) === 1;
         });
     }
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Feature;
+
+use Tests\TestCase;
+use App\Judite\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class AuthenticationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * @test
+     * @group bug7
+     **/
+    public function user_email_login_check_is_case_insensitve()
+    {
+        $user = factory(User::class)->create([
+                'email' => 'a7000@alunos.uminho.pt',
+                'password' => 'password',
+            ]);
+
+        $response = $this->post('/login', [
+                'email' => 'A7000@alunos.uminho.pt',
+                'password' => 'password',
+            ]);
+
+        $response->assertRedirect(route('dashboard'));
+    }
+}

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -14,14 +14,14 @@ class AuthenticationTest extends TestCase
     public function user_email_login_check_is_case_insensitve()
     {
         $user = factory(User::class)->create([
-                'email' => 'a7000@alunos.uminho.pt',
-                'password' => 'password',
-            ]);
+            'email' => 'a7000@alunos.uminho.pt',
+            'password' => 'password',
+        ]);
 
-        $response = $this->post('/login', [
-                'email' => 'A7000@alunos.uminho.pt',
-                'password' => 'password',
-            ]);
+        $response = $this->post(route('login'), [
+            'email' => 'A7000@alunos.uminho.pt',
+            'password' => 'password',
+        ]);
 
         $response->assertRedirect(route('dashboard'));
     }

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -10,10 +10,7 @@ class AuthenticationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    /**
-     * @test
-     * @group bug7
-     **/
+    /** @test **/
     public function user_email_login_check_is_case_insensitve()
     {
         $user = factory(User::class)->create([

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -18,10 +18,7 @@ class RegistrationTest extends TestCase
         Mail::fake();
     }
 
-    /**
-     * @test
-     * @group bug7
-     * */
+    /** @test */
     public function user_email_is_stored_as_lower_case()
     {
         $this->post('/register', [

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -18,6 +18,24 @@ class RegistrationTest extends TestCase
         Mail::fake();
     }
 
+    /**
+     * @test
+     * @group bug7
+     * */
+    public function user_email_is_stored_as_lower_case()
+    {
+        $this->post('/register', [
+            'name' => 'John Doe',
+            'student_number' => 'pG12345',
+            'password' => 'secret',
+            'password_confirmation' => 'secret',
+        ]);
+
+        $expectedEmail = 'pg12345@alunos.uminho.pt';
+        $actualEmail = User::first()->email;
+        $this->assertEquals(0, strcmp($expectedEmail, $actualEmail));
+    }
+
     /** @test */
     public function a_confirmation_email_is_sent_after_registration()
     {

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -21,7 +21,7 @@ class RegistrationTest extends TestCase
     /** @test */
     public function user_email_is_stored_as_lower_case()
     {
-        $this->post('/register', [
+        $this->post(route('register'), [
             'name' => 'John Doe',
             'student_number' => 'pG12345',
             'password' => 'secret',
@@ -36,7 +36,7 @@ class RegistrationTest extends TestCase
     /** @test */
     public function a_confirmation_email_is_sent_after_registration()
     {
-        $this->post('/register', [
+        $this->post(route('register'), [
             'name' => 'John Doe',
             'student_number' => 'pg12345',
             'password' => 'secret',


### PR DESCRIPTION
## Issue
Refers to #7.

## Changes Made
* Allow user registration with any case email
* Enforce lower case email when saving to db
* Override credentials method so that login email is converted to lowercase

## Warning
Don't forget to set the emails already on the production database to lower case! :wink: 