### PR TITLE
Add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 Homestead.json
 Homestead.yaml
 npm-debug.log
+yarn-error.log
 .env
 .php_cs.cache


### PR DESCRIPTION
For those using yarn, this pull request adds the yarn-error.log file to .gitignore :+1: