### PR TITLE
bug: fix settings view

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -227,6 +227,7 @@ return [
         'Schema' => Illuminate\Support\Facades\Schema::class,
         'Session' => Illuminate\Support\Facades\Session::class,
         'Storage' => Illuminate\Support\Facades\Storage::class,
+        'Str' => Illuminate\Support\Str::class,
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,

--- a/resources/views/settings/edit.blade.php
+++ b/resources/views/settings/edit.blade.php
@@ -11,7 +11,7 @@
                 <div class="form-group">
                     <label>Period of enrollments</label>
                     <calendar-enrollments :date="['{{ old('enrollments_start_at') ?: $settings->enrollments_start_at }}', '{{ old('enrollments_end_at') ?: $settings->enrollments_end_at }}']"></calendar-enrollments>
-                    @if (str_contains($errors->first('enrollments_end_at'), 'required'))
+                    @if (Str::contains($errors->first('enrollments_end_at'), 'required'))
                         <div class="form-text text-danger">The enrollments period field is required.</div>
                     @else
                         <div class="form-text text-danger">{{ $errors->first('enrollments_start_at') }}</div>
@@ -22,7 +22,7 @@
                 <div class="form-group">
                     <label>Period of exchanges</label>
                     <calendar-exchanges :date="['{{ old('exchanges_start_at') ?: $settings->exchanges_start_at }}', '{{ old('exchanges_end_at') ?: $settings->exchanges_end_at }}']"></calendar-exchanges>
-                    @if (str_contains($errors->first('exchanges_end_at'), 'required'))
+                    @if (Str::contains($errors->first('exchanges_end_at'), 'required'))
                         <div class="form-text text-danger">The exchanges period field is required.</div>
                     @else
                         <div class="form-text text-danger">{{ $errors->first('exchanges_start_at') }}</div>


### PR DESCRIPTION
There were two calls to _str_contains_ in _resources/views/settings/edit.blade.php_. That isn't compatible with Laravel 6, so I changed the methods to Str::contains and imported the Helper so that those methods could be used in the views.