### PR TITLE
bug: fix enrollments import

### DIFF
--- a/app/Exports/EnrollmentsExport.php
+++ b/app/Exports/EnrollmentsExport.php
@@ -8,9 +8,12 @@ use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\Exportable;
 
 class EnrollmentsExport implements FromCollection, WithMapping, WithHeadings
 {
+    use Exportable;
+
     /**
      * The enrollments collection.
      *
@@ -25,7 +28,7 @@ class EnrollmentsExport implements FromCollection, WithMapping, WithHeadings
      */
     public function __construct(\Illuminate\Support\Collection $enrollments = null)
     {
-        $this->enrollments = $enrollments;
+        $this->enrollments = is_null($enrollments) ? collect() : $enrollments;
     }
 
     /**
@@ -73,7 +76,7 @@ class EnrollmentsExport implements FromCollection, WithMapping, WithHeadings
      */
     public function collection()
     {
-        if ($this->enrollments) {
+        if (!$this->enrollments->isEmpty()) {
             return $this->enrollments;
         }
 

--- a/app/Http/Controllers/Admin/EnrollmentController.php
+++ b/app/Http/Controllers/Admin/EnrollmentController.php
@@ -45,7 +45,7 @@ class EnrollmentController extends Controller
     public function storeImport(ImportRequest $request)
     {
         try {
-            DB::transaction(fn () => Excel::import(new EnrollmentsImport(), $request->enrollments->path()));
+            DB::transaction(fn () => Excel::import(new EnrollmentsImport(), $request->file('enrollments')));
 
             flash('The enrollments file was successfully imported.')->success();
         } catch (InvalidImportFileException $e) {

--- a/app/Imports/EnrollmentsImport.php
+++ b/app/Imports/EnrollmentsImport.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use App\Judite\Models\Course;
 use App\Judite\Models\Student;
 use App\Judite\Models\Enrollment;
+use App\Judite\Models\Shift;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use App\Exceptions\InvalidFieldValueException;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;

--- a/resources/views/enrollments/import.blade.php
+++ b/resources/views/enrollments/import.blade.php
@@ -13,7 +13,7 @@
                 {{-- File input --}}
                 <div class="form-group">
                     <label for="enrollments">Enrollments file</label>
-                    <file-input id="enrollments" file-types=".csv" state="{{ $errors->has('enrollments') ? 'invalid' : 'null' }}" ></file-input>
+                    <file-input name="enrollments" id="enrollments" file-types=".csv" state="{{ $errors->has('enrollments') ? 'invalid' : 'null' }}" ></file-input>
                     @if ($errors->has('enrollments'))
                         <div class="form-text text-danger">{{ $errors->first('enrollments') }}</div>
                     @else


### PR DESCRIPTION
When importing enrollments, a couple of errors were being thrown. This adds the ability to import a .csv file.

However, the file isn't verified in the import, so an unstructured .csv file will return a 500 error.