### PR TITLE
feat: set the institutional domain

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -73,7 +73,7 @@ class RegisterController extends Controller
             $data['student_number'] = strtolower($data['student_number']);
             $user = User::make([
                 'name' => $data['name'],
-                'email' => $data['student_number'].'@alunos.uminho.pt',
+                'email' => $data['student_number'].'@'.config('app.mail_domain'),
                 'password' => bcrypt($data['password']),
             ]);
             $user->verification_token = Str::random(32);

--- a/app/Imports/EnrollmentsImport.php
+++ b/app/Imports/EnrollmentsImport.php
@@ -32,7 +32,7 @@ class EnrollmentsImport implements OnEachRow, WithHeadingRow
             /** @var \App\Judite\Models\User $user */
             $user = User::make([
                 'name' => $row['student_name'] ?? $row['student_id'],
-                'email' => strtolower($row['student_email'] ?? $row['student_id'].'@alunos.uminho.pt'),
+                'email' => strtolower($row['student_email'] ?? $row['student_id'].'@'.config('app.mail_domain')),
                 'password' => bcrypt(Str::random(8)),
             ]);
             $user->verification_token = Str::random(32);

--- a/config/app.php
+++ b/config/app.php
@@ -235,4 +235,18 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Institutional Mail Domain
+    |--------------------------------------------------------------------------
+    |
+    | All the students who register on the platform must have an academic mail address.
+    | Set the domain in the .env file, or else defaults to Universidade do Minho's.
+    | Example: Student number: a82343. Institutional domain: alunos.uminho.pt
+    |   Student e-mail that is going to be used: a82343@alunos.uminho.pt
+    |
+    */
+
+    'mail_domain' => env('STUDENT_INSTITUTIONAL_MAIL_DOMAIN', 'alunos.uminho.pt'),
+
 ];

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -22,7 +22,7 @@ $factory->define(Student::class, function (Faker\Generator $faker) {
     return [
         'user_id' => function () use ($studentNumber) {
             return factory(User::class)->create([
-                'email' => "${studentNumber}@alunos.uminho.pt",
+                'email' => "${studentNumber}@".config('app.mail_domain'),
                 'is_admin' => false,
                 'verified' => true,
             ])->id;

--- a/database/seeds/ImportFeatureSeeder.php
+++ b/database/seeds/ImportFeatureSeeder.php
@@ -35,7 +35,7 @@ class ImportFeatureSeeder extends Seeder
                 'a71220',
             ]);
             $emails = $numbers->map(function ($number) {
-                return $number.'@alunos.uminho.pt';
+                return $number.'@'.config('app.mail_domain');
             });
             $names->each(function ($name, $key) {
                 $user = factory(User::class)->create([

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -19,7 +19,7 @@
                     <label for="student_number">E-mail address</label>
                     <div class="input-group {{ $errors->has('student_number') ? 'is-invalid' : '' }}">
                         <input id="student_number" type="text" class="form-control {{ $errors->has('student_number') ? 'is-invalid' : '' }}" name="student_number" value="{{ old('student_number') }}" required>
-                        <span class="input-group-addon">@alunos.uminho.pt</span>
+                        <span class="input-group-addon">{{ '@'.config('app.mail_domain') }}</span>
                     </div>
                     @if ($errors->has('student_number'))
                         <div class="invalid-feedback">{{ $errors->first('student_number') }}</div>

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Judite\Models\User;
@@ -14,12 +14,12 @@ class AuthenticationTest extends TestCase
     public function user_email_login_check_is_case_insensitve()
     {
         $user = factory(User::class)->create([
-            'email' => 'a7000@alunos.uminho.pt',
+            'email' => 'a7000@'.config('app.mail_domain'),
             'password' => 'password',
         ]);
 
         $response = $this->post(route('login'), [
-            'email' => 'A7000@alunos.uminho.pt',
+            'email' => 'A7000@'.config('app.mail_domain'),
             'password' => 'password',
         ]);
 

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -28,7 +28,7 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'secret',
         ]);
 
-        $expectedEmail = 'pg12345@alunos.uminho.pt';
+        $expectedEmail = 'pg12345@'.config('app.mail_domain');
         $actualEmail = User::first()->email;
         $this->assertEquals(0, strcmp($expectedEmail, $actualEmail));
     }
@@ -43,7 +43,7 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'secret',
         ]);
 
-        $email = 'pg12345@alunos.uminho.pt';
+        $email = 'pg12345@'.config('app.mail_domain');
         $this->assertEquals(1, User::where('email', $email)->count());
         Mail::assertSent(RegistrationConfirmation::class, function ($mail) use ($email) {
             return $mail->hasTo($email);


### PR DESCRIPTION
**Purpose**
Make it usable outside the _alunos.uminho.pt_ domain.

**What has been added**
Swap will now look for an _env_ variable called `STUDENT_INSTITUTIONAL_MAIL_DOMAIN `(didn't come up with a better name, looking forward to suggestions :smile:), and sets it as the e-mail address of students who register on the platform. By default, it will be set to what had been hard-coded until now (alunos.uminho.pt).

**What could be added**
The possibility to define different regex patterns to validate a _student_number_. It is currently hardcoded as `/^(a|pg)[0-9]+$/i` in _app/Providers/AppServiceProvider_.
